### PR TITLE
More WebViews and more diverse links

### DIFF
--- a/BrokenWebViews/TabBarController.swift
+++ b/BrokenWebViews/TabBarController.swift
@@ -9,19 +9,18 @@
 import UIKit
 
 class TabBarController: UITabBarController {
-    let webViewControllerOne = WebViewController()
-    let webViewControllerTwo = WebViewController()
-    let webViewControllerThree = WebViewController()
-    let webViewControllerFour = WebViewController()
+
+    var webViewControllers: [WebViewController] = []
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        webViewControllerOne.tabBarItem = UITabBarItem(title: "First", image: UIImage(named: "first"), tag: 0)
-        webViewControllerTwo.tabBarItem = UITabBarItem(title: "Second", image: UIImage(named: "second"), tag: 1)
-        webViewControllerThree.tabBarItem = UITabBarItem(title: "Third", image: UIImage(named: "first"), tag: 2)
-        webViewControllerFour.tabBarItem = UITabBarItem(title: "Fourth", image: UIImage(named: "second"), tag: 3)
+        for i in 0 ..< 8 {
+            let webViewController = WebViewController()
+            webViewController.tabBarItem = UITabBarItem(title: "#\(i)", image: UIImage(named: "first"), tag: i)
+            webViewControllers.append(webViewController)
+        }
 
-        viewControllers = [webViewControllerOne, webViewControllerTwo, webViewControllerThree, webViewControllerFour]
+        viewControllers = webViewControllers
     }
 }

--- a/BrokenWebViews/WebViewController.swift
+++ b/BrokenWebViews/WebViewController.swift
@@ -15,6 +15,20 @@ class WebViewController: UIViewController {
         case down
     }
 
+    let links = [
+        "https://kotaku.com/the-secret-douglas-adams-rpg-people-have-been-playing-f-1681986562",
+        "http://www.eurogamer.net/articles/2017-07-14-zelda-breath-of-the-wild-captured-memories-locations-4857",
+        "https://arstechnica.com/gadgets/2017/09/macos-10-13-high-sierra-the-ars-technica-review/",
+        "https://www.reddit.com/r/podcasts/comments/7vcunq/weekly_podcast_post_submit_your_links_here/",
+        "http://ca.ign.com/articles/2018/02/07/sid-meiers-civilization-6-rise-and-fall-review",
+        "https://arstechnica.com/gadgets/2017/09/ios-11-thoroughly-reviewed/6/#h1",
+        "http://ca.ign.com/articles/2018/02/01/iconoclasts-review",
+        "http://www.eurogamer.net/articles/2018-02-02-lost-sphear-review",
+        "http://ca.ign.com/articles/2018/01/31/gorogoa-review",
+        "http://www.eurogamer.net/articles/2018-02-02-dissidia-final-fantasy-nt-review",
+        "http://driving.ca/porsche/macan/reviews/road-test/suv-review-2018-porsche-macan-gts",
+    ]
+
     let webView = WKWebView()
     let reloadButton = UIButton(type: .system)
 
@@ -49,7 +63,7 @@ class WebViewController: UIViewController {
 
         lastContentOffset = webView.scrollView.contentOffset
 
-        webView.load(URLRequest(url: URL(string: "http://www.eurogamer.net/articles/2017-07-14-zelda-breath-of-the-wild-captured-memories-locations-4857")!))
+        webView.load(URLRequest(url: URL(string: self.links[Int(arc4random_uniform(UInt32(links.count)))])!))
     }
 
     func showToolbar() {


### PR DESCRIPTION
Steps to reproduce:

- Start the app, I run it from Xcode
- For every tab:
- switch to the tab, let the page load, scroll to the bottom (they should all load)
- Then after having loaded all tabs, just select each of them in reverse order
- When I am at tab #2 I see the message below in the console and the tab shows up as mostly blank with just a small part rendered at the top. Hitting reload doesn't help.

```
2018-02-09 10:59:00.872607-0500 BrokenWebViews[523:42452] [ProcessSuspension]  0x1c8273180 - ProcessAssertion() Unable to acquire assertion for process with PID 0
2018-02-09 10:59:01.787415-0500 BrokenWebViews[523:42452] [ProcessSuspension]  0x1c407db80 - ProcessAssertion() Unable to acquire assertion for process with PID 0
2018-02-09 10:59:02.054650-0500 BrokenWebViews[523:42452] [ProcessSuspension]  0x1c42704c0 - ProcessAssertion() Unable to acquire assertion for process with PID 0
2018-02-09 10:59:03.104488-0500 BrokenWebViews[523:41933] [ProcessSuspension]  0x1c82613c0 - ProcessAssertion() Unable to acquire assertion for process with PID 0
2018-02-09 10:59:30.875958-0500 BrokenWebViews[523:40938] Could not signal service com.apple.WebKit.WebContent: 113: Could not find specified service
2018-02-09 10:59:31.770924-0500 BrokenWebViews[523:40938] Could not signal service com.apple.WebKit.WebContent: 113: Could not find specified service
2018-02-09 10:59:32.055199-0500 BrokenWebViews[523:40938] Could not signal service com.apple.WebKit.WebContent: 113: Could not find specified service
2018-02-09 10:59:33.098812-0500 BrokenWebViews[523:40938] Could not signal service com.apple.WebKit.WebContent: 113: Could not find specified service
2018-02-09 10:59:57.253889-0500 BrokenWebViews[523:42702] [ProcessSuspension]  0x1c807c800 - ProcessAssertion() Unable to acquire assertion for process with PID 0
```
